### PR TITLE
Cleanup uploaded files

### DIFF
--- a/packages/service/eslint.config.mjs
+++ b/packages/service/eslint.config.mjs
@@ -25,7 +25,7 @@ export default tseslint.config(
       // disabled because I keep running into https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69846
       "@typescript-eslint/no-misused-promises": ["off"],
       // let me use 'any' when I choose to
-      "@typescript-eslint/no-unsafe-assignment": ["off"],
+      "@typescript-eslint/no-unsafe-assignment": ["warn"],
       "@typescript-eslint/no-unsafe-argument": ["warn"],
       "@typescript-eslint/no-unsafe-call": ["warn"],
       "@typescript-eslint/no-explicit-any": ["warn"],

--- a/packages/service/src/routes/armada.ts
+++ b/packages/service/src/routes/armada.ts
@@ -1,8 +1,8 @@
 import express from "express";
 import multer from "multer";
 import debug from "debug";
+import fs from "fs";
 const log = debug("app:armada");
-
 const handleUpload = multer({
   dest: "/tmp/uploads",
   limits: {
@@ -26,6 +26,11 @@ router.post("/upload", (req, res, next) => {
       } else {
         log("Received file", req.file);
         res.status(200).send({ status: "success" });
+        fs.rm(req.file.path, (err) => {
+          if (err) {
+            log({ err });
+          }
+        });
       }
     }
   });


### PR DESCRIPTION
After they've been uploaded we don't need to keep them long term; delete them immediately after the upload was confirmed successful.